### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/integrations.go
+++ b/pkg/connector/integrations.go
@@ -39,10 +39,9 @@ func integrationResource(ctx context.Context, integration *celigo.Integration) (
 		"description": integration.Description,
 	}
 
-	integrationTraitOptions := []rs.AppTraitOption{
-		rs.WithAppProfile(profile),
-	}
-	resource, err := rs.NewAppResource(integration.Name, integrationsResourceType, integration.Id, integrationTraitOptions)
+	integrationTraitOptions := []rs.AppTraitOption{}
+	resource, err := rs.NewAppResource(integration.Name, integrationsResourceType, integration.Id, integrationTraitOptions,
+		rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/roles.go
+++ b/pkg/connector/roles.go
@@ -37,11 +37,10 @@ func newRoleResource(ctx context.Context, role string) (*v2.Resource, error) {
 		"name": role,
 	}
 
-	roleTraitOptions := []rs.RoleTraitOption{
-		rs.WithRoleProfile(profile),
-	}
+	roleTraitOptions := []rs.RoleTraitOption{}
 
-	resource, err := rs.NewRoleResource(role, roleResourceType, role, roleTraitOptions)
+	resource, err := rs.NewRoleResource(role, roleResourceType, role, roleTraitOptions,
+		rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -29,11 +29,11 @@ func userResource(ctx context.Context, user *celigo.User) (*v2.Resource, error) 
 	}
 
 	userTraits := []rs.UserTraitOption{
-		rs.WithUserProfile(profile),
 		rs.WithUserLogin(user.Details.Email),
 	}
 
-	resource, err := rs.NewUserResource(user.Details.Email, userResourceType, user.Id, userTraits)
+	resource, err := rs.NewUserResource(user.Details.Email, userResourceType, user.Id, userTraits,
+		rs.WithResourceProfile(profile))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
